### PR TITLE
Fix: Reconnection not working in some cases

### DIFF
--- a/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
+++ b/Sources/NWWebSocket/Model/Client/NWWebSocket.swift
@@ -143,10 +143,18 @@ open class NWWebSocket: WebSocketConnection {
             }
 
             if let error = error {
-                self.reportErrorOrDisconnection(error)
+                self.handleErrorWhileReceivingMessage(error)
             } else {
                 self.listen()
             }
+        }
+    }
+
+    private func handleErrorWhileReceivingMessage(_ error: NWError) {
+        if case .posix = error {
+            tearDownConnection(error: error)
+        } else {
+            reportErrorOrDisconnection(error)
         }
     }
 


### PR DESCRIPTION
It is found that same connection errors are reported through `receiveMessage` callback, in this case, the state of connection is still `ready` and `tearDownConnection` is not called, therefore `connect` is bypassed later when reconnection made.

This change identify the errors triggering reconnection, i.e. POSIX error and tear down connection accordingly.